### PR TITLE
Fix pie chart highlight regression

### DIFF
--- a/js/dashboard-main.js
+++ b/js/dashboard-main.js
@@ -529,9 +529,12 @@ const ChartModule = {
             }
         };
         
-        Plotly.newPlot('ligandChart', [trace], layout, pieChartConfig).then(() => {
+        const plotResult = Plotly.newPlot('ligandChart', [trace], layout, pieChartConfig);
+        if (plotResult && typeof plotResult.then === 'function') {
+            plotResult.then(() => applyPieHighlight('ligandChart', isFiltered));
+        } else {
             applyPieHighlight('ligandChart', isFiltered);
-        });
+        }
 
         document.getElementById('ligandChart').on('plotly_click', function(data) {
             const category = data.points[0].label;


### PR DESCRIPTION
## Summary
- Ensure pie charts apply highlight regardless of Plotly.newPlot return type

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6896c87f3358832a9c6e22bef28e24cb